### PR TITLE
Add find_packages() so it will package proctor module.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,6 @@ version = '0.0.4'
 setup(
     name='django-proctor',
     version=version,
+    packages=find_packages(),
     install_requires=['Django', 'requests', 'pyOpenSSL', 'ndg-httpsclient'],
 )


### PR DESCRIPTION
I was having an issue installing this from git. It would just install an egg-info directory into my site-packages instead of the whole module. It turns out that setuptools didn't actually know what to package.
This fixed it for me.

PS: Please put this on PyPI. :pray: 