### PR TITLE
DJANGO-1236: add Python 3.9 test suites

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
 envlist =
     py27
-    py39-django111
-    py39-django22
+    py{36,39}-django{111,22}
 
 [testenv]
 deps =
     py27: Django < 2.0
-    py39-django111: Django == 1.11.*
-    py39-django22: Django == 2.2.*
+    django111: Django == 1.11.*
+    django22: Django == 2.2.*
     mock
     py27: pytest < 4.6.5
-    py39: pytest
+    py{36,39}: pytest
     pytest-cov
     pytest-flake8
 setenv = DJANGO_SETTINGS_MODULE = proctor.tests.settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,17 @@
 [tox]
 envlist =
     py27
-    py36-django111
-    py36-django22
+    py39-django111
+    py39-django22
 
 [testenv]
 deps =
     py27: Django < 2.0
-    py36-django111: Django == 1.11.*
-    py36-django22: Django == 2.2.*
+    py39-django111: Django == 1.11.*
+    py39-django22: Django == 2.2.*
     mock
     py27: pytest < 4.6.5
-    py36: pytest
+    py39: pytest
     pytest-cov
     pytest-flake8
 setenv = DJANGO_SETTINGS_MODULE = proctor.tests.settings


### PR DESCRIPTION
DJANGO-1236 was merged into our stale internal repo (See DJANGO-1303 for details). This pull request adds those changes into this repo.
I cherry-picked the original DJANGO-1236 changes in the first commit, except that the version bump has been dropped (no changes functionality-wise).
Then I tweaked some tox settings to better maintain Python 3.6 compatibility.